### PR TITLE
Add Dynamic Data Functionality to BOL NFT

### DIFF
--- a/backend/contracts/Selector.sol
+++ b/backend/contracts/Selector.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.7.5;
 
+import "./interfaces/IERC1948.sol";
+
 interface Solidity101 {
     function hello() external pure;
 
@@ -12,8 +14,17 @@ interface Solidity101 {
 contract Selector {
     /// @dev Calculate the interface
     /// @dev Requires the import of the interface
+    function calculateSelectorReadData() public pure returns (bytes4) {
+        IERC1948 i;
+        return i.readData.selector;
+    }
+
+    function calculateSelectorWriteData() public pure returns (bytes4) {
+        IERC1948 i;
+        return i.writeData.selector;
+    }
+
     function calculateSelector() public pure returns (bytes4) {
-        Solidity101 i;
-        return i.hello.selector ^ i.world.selector;
+        return calculateSelectorReadData() ^ calculateSelectorWriteData();
     }
 }

--- a/backend/contracts/Selector.sol
+++ b/backend/contracts/Selector.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.5;
+
+interface Solidity101 {
+    function hello() external pure;
+
+    function world(int256) external pure;
+}
+
+/// @title Contract for calculating Interface IDs
+contract Selector {
+    /// @dev Calculate the interface
+    /// @dev Requires the import of the interface
+    function calculateSelector() public pure returns (bytes4) {
+        Solidity101 i;
+        return i.hello.selector ^ i.world.selector;
+    }
+}

--- a/backend/contracts/interfaces/IERC1948.sol
+++ b/backend/contracts/interfaces/IERC1948.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.5;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/**
+ * @dev Interface of the ERC1948 contract.
+ */
+interface IERC1948 is IERC721 {
+    /**
+     * @dev Emitted when `oldData` is replaced with `newData` in storage of `tokenId`.
+     *
+     * Note that `oldData` or `newData` may be empty bytes.
+     */
+    event DataUpdated(
+        uint256 indexed tokenId,
+        bytes32 oldData,
+        bytes32 newData
+    );
+
+    /**
+     * @dev Reads the data of a specified token. Returns the current data in
+     * storage of `tokenId`.
+     *
+     * @param tokenId The token to read the data off.
+     *
+     * @return A bytes32 representing the current data stored in the token.
+     */
+    function readData(uint256 tokenId) external view returns (bytes32);
+
+    /**
+     * @dev Updates the data of a specified token. Writes `newData` into storage
+     * of `tokenId`.
+     *
+     * @param tokenId The token to write data to.
+     * @param newData The data to be written to the token.
+     *
+     * Emits a `DataUpdated` event.
+     */
+    function writeData(uint256 tokenId, bytes32 newData) external;
+}

--- a/backend/migrations/3_deploy_utils.js
+++ b/backend/migrations/3_deploy_utils.js
@@ -1,0 +1,5 @@
+const Selector = artifacts.require("Selector");
+
+module.exports = function (deployer) {
+  deployer.deploy(Selector);
+};

--- a/backend/test/test_erc1948.js
+++ b/backend/test/test_erc1948.js
@@ -1,0 +1,35 @@
+const BillOfLading = artifacts.require("BillOfLading");
+
+const {
+  constants, // Common constants, like the zero address and largest integers
+  expectEvent, // Assertions for emitted events
+  expectRevert, // Assertions for transactions that should fail
+} = require("@openzeppelin/test-helpers");
+const { assertion } = require("@openzeppelin/test-helpers/src/expectRevert");
+const { web3 } = require("@openzeppelin/test-helpers/src/setup");
+
+contract("Bill Of Lading", (accounts) => {
+  var instance;
+
+  before("create instance", async () => {
+    instance = await BillOfLading.deployed();
+    await instance.mint(accounts[0]);
+  });
+
+  describe("writeData", () => {
+    it("should emit a DataUpdated event", async () => {
+      var _newData = web3.utils.asciiToHex("Hello World");
+      let tx = await instance.writeData(0, _newData);
+      expectEvent(tx, "DataUpdated");
+    });
+  });
+  describe("readData", () => {
+    it("should read the event in storage", async () => {
+      let data = await instance.readData(0, { from: accounts[0] });
+      assert.equal(
+        data,
+        web3.utils.padRight(web3.utils.asciiToHex("Hello World"), 64)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Considering that we are trying to reduce the amount of data we have on chain, it didn't make sense to hard code specific fields which would have to be updated by specific function calls. In fact such a series of function calls would be costly.
Instead I opted to use ERC 1948, which is an extension to the ERC 721 standard and adds a data container which can be updated in a standardized way.

This is important because, although `bytes32` isn't enough to create a paragraph, it is possibly enough to store a hex digest which when paired with ipfs can store data in a distributed manner. This opens up the opportunity to store JSON data off chain in a secure manner which can't be edited (otherwise the hash will change). This data can be stored and then be queried by the front-end to present users with more information that would otherwise be impossible to store on chain. 

This doesn't close issue #15 completely, but it is a step in the right direction. Next steps include finding how to store the hex digest on chain in a secure and standardized manner so we can retrieve it.

See [how to create an ipfs compatible multihash](https://stackoverflow.com/questions/40998621/how-to-create-an-ipfs-compatible-multihash)