### PR TITLE
Add Interface Files for ERC998

### DIFF
--- a/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.5;
+
+/// @title ERC998ERC20 Bottom-Up Composable Fungible Token
+/// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
+/// Note: The ERC-165 identifier for this interface is 0xffafa991
+interface ERC998ERC20BottomUp {
+    /// @dev This emits when a token is transferred to an ERC721 token
+    /// @param _toContract The contract the token is transferred to
+    /// @param _toTokenId The token the token is transferred to
+    /// @param _amount The amount of tokens transferred
+    event TransferToParent(
+        address indexed _toContract,
+        uint256 indexed _toTokenId,
+        uint256 _amount
+    );
+
+    /// @dev This emits when a token is transferred from an ERC721 token
+    /// @param _fromContract The contract the token is transferred from
+    /// @param _fromTokenId The token the token is transferred from
+    /// @param _amount The amount of tokens transferred
+    event TransferFromParent(
+        address indexed _fromContract,
+        uint256 indexed _fromTokenId,
+        uint256 _amount
+    );
+
+    /// @notice Get the balance of a non-fungible parent token
+    /// @param _tokenContract The contract tracking the parent token
+    /// @param _tokenId The ID of the parent token
+    /// @return amount The balance of the token
+    function balanceOfToken(address _tokenContract, uint256 _tokenId)
+        external
+        view
+        returns (uint256 amount);
+
+    /// @notice Transfer tokens from owner address to a token
+    /// @param _from The owner address
+    /// @param _toContract The ERC721 contract of the receiving token
+    /// @param _toToken The receiving token
+    /// @param _amount The amount of tokens to transfer
+    function transferToParent(
+        address _from,
+        address _toContract,
+        uint256 _toTokenId,
+        uint256 _amount
+    ) external;
+
+    /// @notice Transfer token from a token to an address
+    /// @param _fromContract The address of the owning contract
+    /// @param _fromTokenId The owning token
+    /// @param _to The address the token is transferred to
+    /// @param _amount The amount of tokens to transfer
+    function transferFromParent(
+        address _fromContract,
+        uint256 _fromTokenId,
+        address _to,
+        uint256 _amount
+    ) external;
+
+    /// @notice Transfer token from a token to an address, using ERC223 semantics
+    /// @param _fromContract The address of the owning contract
+    /// @param _fromTokenId The owning token
+    /// @param _to The address the token is transferred to
+    /// @param _amount The amount of tokens to transfer
+    /// @param _data Additional data with no specified format, can be used to specify the sender tokenId
+    function transferFromParentERC223(
+        address _fromContract,
+        uint256 _fromTokenId,
+        address _to,
+        uint256 _amount,
+        bytes _data
+    ) external;
+
+    /// @notice Transfer a token from a token to another token
+    /// @param _fromContract The address of the owning contract
+    /// @param _fromTokenId The owning token
+    /// @param _toContract The ERC721 contract of the receiving token
+    /// @param _toToken The receiving token
+    /// @param _amount The amount tokens to transfer
+    function transferAsChild(
+        address _fromContract,
+        uint256 _fromTokenId,
+        address _toContract,
+        uint256 _toTokenId,
+        uint256 _amount
+    ) external;
+}

--- a/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.5;
+
+/// @title ERC998ERC20 Top-Down Composable Non-Fungible Token
+/// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
+///  Note: the ERC-165 identifier for this interface is 0x7294ffed
+interface ERC998ERC20TopDown {
+    /// @dev This emits when a token receives ERC20 tokens.
+    /// @param _from The prior owner of the token.
+    /// @param _toTokenId The token that receives the ERC20 tokens.
+    /// @param _erc20Contract The ERC20 contract.
+    /// @param _value The number of ERC20 tokens received.
+    event ReceivedERC20(
+        address indexed _from,
+        uint256 indexed _toTokenId,
+        address indexed _erc20Contract,
+        uint256 _value
+    );
+
+    /// @dev This emits when a token transfers ERC20 tokens.
+    /// @param _tokenId The token that owned the ERC20 tokens.
+    /// @param _to The address that receives the ERC20 tokens.
+    /// @param _erc20Contract The ERC20 contract.
+    /// @param _value The number of ERC20 tokens transferred.
+    event TransferERC20(
+        uint256 indexed _fromTokenId,
+        address indexed _to,
+        address indexed _erc20Contract,
+        uint256 _value
+    );
+
+    /// @notice A token receives ERC20 tokens
+    /// @param _from The prior owner of the ERC20 tokens
+    /// @param _value The number of ERC20 tokens received
+    /// @param _data Up to the first 32 bytes contains an integer which is the receiving tokenId.
+    function tokenFallback(
+        address _from,
+        uint256 _value,
+        bytes _data
+    ) external;
+
+    /// @notice Look up the balance of ERC20 tokens for a specific token and ERC20 contract
+    /// @param _tokenId The token that owns the ERC20 tokens
+    /// @param _erc20Contract The ERC20 contract
+    /// @return The number of ERC20 tokens owned by a token from an ERC20 contract
+    function balanceOfERC20(uint256 _tokenId, address _erc20Contract)
+        external
+        view
+        returns (uint256);
+
+    /// @notice Transfer ERC20 tokens to address
+    /// @param _tokenId The token to transfer from
+    /// @param _value The address to send the ERC20 tokens to
+    /// @param _erc20Contract The ERC20 contract
+    /// @param _value The number of ERC20 tokens to transfer
+    function transferERC20(
+        uint256 _tokenId,
+        address _to,
+        address _erc20Contract,
+        uint256 _value
+    ) external;
+
+    /// @notice Transfer ERC20 tokens to address or ERC20 top-down composable
+    /// @param _tokenId The token to transfer from
+    /// @param _value The address to send the ERC20 tokens to
+    /// @param _erc223Contract The ERC223 token contract
+    /// @param _value The number of ERC20 tokens to transfer
+    /// @param _data Additional data with no specified format, can be used to specify tokenId to transfer to
+    function transferERC223(
+        uint256 _tokenId,
+        address _to,
+        address _erc223Contract,
+        uint256 _value,
+        bytes _data
+    ) external;
+
+    /// @notice Get ERC20 tokens from ERC20 contract.
+    /// @param _from The current owner address of the ERC20 tokens that are being transferred.
+    /// @param _tokenId The token to transfer the ERC20 tokens to.
+    /// @param _erc20Contract The ERC20 token contract
+    /// @param _value The number of ERC20 tokens to transfer
+    function getERC20(
+        address _from,
+        uint256 _tokenId,
+        address _erc20Contract,
+        uint256 _value
+    ) external;
+}
+
+/// @dev The ERC-165 identifier for this interface is 0xc5fd96cd
+interface ERC998ERC20TopDownEnumerable {
+    /// @notice Get the number of ERC20 contracts that token owns ERC20 tokens from
+    /// @param _tokenId The token that owns ERC20 tokens.
+    /// @return uint256 The number of ERC20 contracts
+    function totalERC20Contracts(uint256 _tokenId)
+        external
+        view
+        returns (uint256);
+
+    /// @notice Get an ERC20 contract that token owns ERC20 tokens from by index
+    /// @param _tokenId The token that owns ERC20 tokens.
+    /// @param _index The index position of the ERC20 contract.
+    /// @return address The ERC20 contract
+    function erc20ContractByIndex(uint256 _tokenId, uint256 _index)
+        external
+        view
+        returns (address);
+}

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.5;
+
+/// @title ERC998ERC721 Bottom-Up Composable Non-Fungible Token
+/// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
+///  Note: the ERC-165 identifier for this interface is 0xa1b23002
+interface ERC998ERC721BottomUp {
+    /// @dev This emits when a token is transferred to an ERC721 token
+    /// @param _toContract The contract the token is transferred to
+    /// @param _toTokenId The token the token is transferred to
+    /// @param _tokenId The token that is transferred
+    event TransferToParent(
+        address indexed _toContract,
+        uint256 indexed _toTokenId,
+        uint256 _tokenId
+    );
+
+    /// @dev This emits when a token is transferred from an ERC721 token
+    /// @param _fromContract The contract the token is transferred from
+    /// @param _fromTokenId The token the token is transferred from
+    /// @param _tokenId The token that is transferred
+    event TransferFromParent(
+        address indexed _fromContract,
+        uint256 indexed _fromTokenId,
+        uint256 _tokenId
+    );
+
+    /// @notice Get the root owner of tokenId.
+    /// @param _tokenId The token to query for a root owner address
+    /// @return rootOwner The root owner at the top of tree of tokens and ERC998 magic value.
+    function rootOwnerOf(uint256 _tokenId)
+        external
+        view
+        returns (bytes32 rootOwner);
+
+    /// @notice Get the owner address and parent token (if there is one) of a token
+    /// @param _tokenId The tokenId to query.
+    /// @return tokenOwner The owner address of the token
+    /// @return parentTokenId The parent owner of the token and ERC998 magic value
+    /// @return isParent True if parentTokenId is a valid parent tokenId and false if there is no parent tokenId
+    function tokenOwnerOf(uint256 _tokenId)
+        external
+        view
+        returns (
+            bytes32 tokenOwner,
+            uint256 parentTokenId,
+            bool isParent
+        );
+
+    /// @notice Transfer token from owner address to a token
+    /// @param _from The owner address
+    /// @param _toContract The ERC721 contract of the receiving token
+    /// @param _toToken The receiving token
+    /// @param _data Additional data with no specified format
+    function transferToParent(
+        address _from,
+        address _toContract,
+        uint256 _toTokenId,
+        uint256 _tokenId,
+        bytes _data
+    ) external;
+
+    /// @notice Transfer token from a token to an address
+    /// @param _fromContract The address of the owning contract
+    /// @param _fromTokenId The owning token
+    /// @param _to The address the token is transferred to.
+    /// @param _tokenId The token that is transferred
+    /// @param _data Additional data with no specified format
+    function transferFromParent(
+        address _fromContract,
+        uint256 _fromTokenId,
+        address _to,
+        uint256 _tokenId,
+        bytes _data
+    ) external;
+
+    /// @notice Transfer a token from a token to another token
+    /// @param _fromContract The address of the owning contract
+    /// @param _fromTokenId The owning token
+    /// @param _toContract The ERC721 contract of the receiving token
+    /// @param _toToken The receiving token
+    /// @param _tokenId The token that is transferred
+    /// @param _data Additional data with no specified format
+    function transferAsChild(
+        address _fromContract,
+        uint256 _fromTokenId,
+        address _toContract,
+        uint256 _toTokenId,
+        uint256 _tokenId,
+        bytes _data
+    ) external;
+}
+
+/// @dev The ERC-165 identifier for this interface is 0x8318b539
+interface ERC998ERC721BottomUpEnumerable {
+    /// @notice Get the number of ERC721 tokens owned by parent token.
+    /// @param _parentContract The contract the parent ERC721 token is from.
+    /// @param _parentTokenId The parent tokenId that owns tokens
+    //  @return uint256 The number of ERC721 tokens owned by parent token.
+    function totalChildTokens(address _parentContract, uint256 _parentTokenId)
+        external
+        view
+        returns (uint256);
+
+    /// @notice Get a child token by index
+    /// @param _parentContract The contract the parent ERC721 token is from.
+    /// @param _parentTokenId The parent tokenId that owns the token
+    /// @param _index The index position of the child token
+    /// @return uint256 The child tokenId owned by the parent token
+    function childTokenByIndex(
+        address _parentContract,
+        uint256 _parentTokenId,
+        uint256 _index
+    ) external view returns (uint256);
+}

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.4.24;
+
+/// @title ERC998ERC721 Top-Down Composable Non-Fungible Token
+/// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
+///  Note: the ERC-165 identifier for this interface is 0x1efdf36a
+interface ERC998ERC721TopDown {
+    /// @dev This emits when a token receives a child token.
+    /// @param _from The prior owner of the token.
+    /// @param _toTokenId The token that receives the child token.
+    event ReceivedChild(
+        address indexed _from,
+        uint256 indexed _toTokenId,
+        address indexed _childContract,
+        uint256 _childTokenId
+    );
+
+    /// @dev This emits when a child token is transferred from a token to an address.
+    /// @param _fromTokenId The parent token that the child token is being transferred from.
+    /// @param _to The new owner address of the child token.
+    event TransferChild(
+        uint256 indexed _fromTokenId,
+        address indexed _to,
+        address indexed _childContract,
+        uint256 _childTokenId
+    );
+
+    /// @notice Get the root owner of tokenId.
+    /// @param _tokenId The token to query for a root owner address
+    /// @return rootOwner The root owner at the top of tree of tokens and ERC998 magic value.
+    function rootOwnerOf(uint256 _tokenId)
+        public
+        view
+        returns (bytes32 rootOwner);
+
+    /// @notice Get the root owner of a child token.
+    /// @param _childContract The contract address of the child token.
+    /// @param _childTokenId The tokenId of the child.
+    /// @return rootOwner The root owner at the top of tree of tokens and ERC998 magic value.
+    function rootOwnerOfChild(address _childContract, uint256 _childTokenId)
+        public
+        view
+        returns (bytes32 rootOwner);
+
+    /// @notice Get the parent tokenId of a child token.
+    /// @param _childContract The contract address of the child token.
+    /// @param _childTokenId The tokenId of the child.
+    /// @return parentTokenOwner The parent address of the parent token and ERC998 magic value
+    /// @return parentTokenId The parent tokenId of _tokenId
+    function ownerOfChild(address _childContract, uint256 _childTokenId)
+        external
+        view
+        returns (bytes32 parentTokenOwner, uint256 parentTokenId);
+
+    /// @notice A token receives a child token
+    /// @param _operator The address that caused the transfer.
+    /// @param _from The owner of the child token.
+    /// @param _childTokenId The token that is being transferred to the parent.
+    /// @param _data Up to the first 32 bytes contains an integer which is the receiving parent tokenId.
+    function onERC721Received(
+        address _operator,
+        address _from,
+        uint256 _childTokenId,
+        bytes _data
+    ) external returns (bytes4);
+
+    /// @notice Transfer child token from top-down composable to address.
+    /// @param _fromTokenId The owning token to transfer from.
+    /// @param _to The address that receives the child token
+    /// @param _childContract The ERC721 contract of the child token.
+    /// @param _childTokenId The tokenId of the token that is being transferred.
+    function transferChild(
+        uint256 _fromTokenId,
+        address _to,
+        address _childContract,
+        uint256 _childTokenId
+    ) external;
+
+    /// @notice Transfer child token from top-down composable to address.
+    /// @param _fromTokenId The owning token to transfer from.
+    /// @param _to The address that receives the child token
+    /// @param _childContract The ERC721 contract of the child token.
+    /// @param _childTokenId The tokenId of the token that is being transferred.
+    function safeTransferChild(
+        uint256 _fromTokenId,
+        address _to,
+        address _childContract,
+        uint256 _childTokenId
+    ) external;
+
+    /// @notice Transfer child token from top-down composable to address.
+    /// @param _fromTokenId The owning token to transfer from.
+    /// @param _to The address that receives the child token
+    /// @param _childContract The ERC721 contract of the child token.
+    /// @param _childTokenId The tokenId of the token that is being transferred.
+    /// @param _data Additional data with no specified format
+    function safeTransferChild(
+        uint256 _fromTokenId,
+        address _to,
+        address _childContract,
+        uint256 _childTokenId,
+        bytes _data
+    ) external;
+
+    /// @notice Transfer bottom-up composable child token from top-down composable to other ERC721 token.
+    /// @param _fromTokenId The owning token to transfer from.
+    /// @param _toContract The ERC721 contract of the receiving token
+    /// @param _toToken The receiving token
+    /// @param _childContract The bottom-up composable contract of the child token.
+    /// @param _childTokenId The token that is being transferred.
+    /// @param _data Additional data with no specified format
+    function transferChildToParent(
+        uint256 _fromTokenId,
+        address _toContract,
+        uint256 _toTokenId,
+        address _childContract,
+        uint256 _childTokenId,
+        bytes _data
+    ) external;
+
+    /// @notice Get a child token from an ERC721 contract.
+    /// @param _from The address that owns the child token.
+    /// @param _tokenId The token that becomes the parent owner
+    /// @param _childContract The ERC721 contract of the child token
+    /// @param _childTokenId The tokenId of the child token
+    function getChild(
+        address _from,
+        uint256 _tokenId,
+        address _childContract,
+        uint256 _childTokenId
+    ) external;
+}
+
+///  @dev The ERC-165 identifier for this interface is 0xa344afe4
+interface ERC998ERC721TopDownEnumerable {
+    /// @notice Get the total number of child contracts with tokens that are owned by tokenId.
+    /// @param _tokenId The parent token of child tokens in child contracts
+    /// @return uint256 The total number of child contracts with tokens owned by tokenId.
+    function totalChildContracts(uint256 _tokenId)
+        external
+        view
+        returns (uint256);
+
+    /// @notice Get child contract by tokenId and index
+    /// @param _tokenId The parent token of child tokens in child contract
+    /// @param _index The index position of the child contract
+    /// @return childContract The contract found at the tokenId and index.
+    function childContractByIndex(uint256 _tokenId, uint256 _index)
+        external
+        view
+        returns (address childContract);
+
+    /// @notice Get the total number of child tokens owned by tokenId that exist in a child contract.
+    /// @param _tokenId The parent token of child tokens
+    /// @param _childContract The child contract containing the child tokens
+    /// @return uint256 The total number of child tokens found in child contract that are owned by tokenId.
+    function totalChildTokens(uint256 _tokenId, address _childContract)
+        external
+        view
+        returns (uint256);
+
+    /// @notice Get child token owned by tokenId, in child contract, at index position
+    /// @param _tokenId The parent token of the child token
+    /// @param _childContract The child contract of the child token
+    /// @param _index The index position of the child token.
+    /// @return childTokenId The child tokenId for the parent token, child token and index
+    function childTokenByIndex(
+        uint256 _tokenId,
+        address _childContract,
+        uint256 _index
+    ) external view returns (uint256 childTokenId);
+}


### PR DESCRIPTION
ERC998 is a standard for composable tokens. Adding this interface files will make issues #30 and #31 easier to complete as any functions missing will raise a compilation error when the contracts get compiled.

It's important to reference the EIP when coding the implementations so as to stay true to the source and correctly code the functions.

ERC998 EIP: https://eips.ethereum.org/EIPS/eip-998

Example Code base utilizing the ERC998:
https://github.com/mattlockyer/composables-998/