### PR TITLE
Fix ERC998 Interfaces

### DIFF
--- a/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
@@ -2,10 +2,12 @@
 
 pragma solidity ^0.7.5;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 /// @title ERC998ERC20 Bottom-Up Composable Fungible Token
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
 /// Note: The ERC-165 identifier for this interface is 0xffafa991
-interface ERC998ERC20BottomUp {
+interface IERC998ERC20BottomUp is IERC20 {
     /// @dev This emits when a token is transferred to an ERC721 token
     /// @param _toContract The contract the token is transferred to
     /// @param _toTokenId The token the token is transferred to

--- a/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20BottomUp.sol
@@ -38,7 +38,7 @@ interface ERC998ERC20BottomUp {
     /// @notice Transfer tokens from owner address to a token
     /// @param _from The owner address
     /// @param _toContract The ERC721 contract of the receiving token
-    /// @param _toToken The receiving token
+    /// @param _toTokenId The receiving token
     /// @param _amount The amount of tokens to transfer
     function transferToParent(
         address _from,
@@ -70,14 +70,14 @@ interface ERC998ERC20BottomUp {
         uint256 _fromTokenId,
         address _to,
         uint256 _amount,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Transfer a token from a token to another token
     /// @param _fromContract The address of the owning contract
     /// @param _fromTokenId The owning token
     /// @param _toContract The ERC721 contract of the receiving token
-    /// @param _toToken The receiving token
+    /// @param _toTokenId The receiving token
     /// @param _amount The amount tokens to transfer
     function transferAsChild(
         address _fromContract,

--- a/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
@@ -19,7 +19,7 @@ interface ERC998ERC20TopDown {
     );
 
     /// @dev This emits when a token transfers ERC20 tokens.
-    /// @param _tokenId The token that owned the ERC20 tokens.
+    /// @param _fromTokenId The token that owned the ERC20 tokens.
     /// @param _to The address that receives the ERC20 tokens.
     /// @param _erc20Contract The ERC20 contract.
     /// @param _value The number of ERC20 tokens transferred.
@@ -37,7 +37,7 @@ interface ERC998ERC20TopDown {
     function tokenFallback(
         address _from,
         uint256 _value,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Look up the balance of ERC20 tokens for a specific token and ERC20 contract
@@ -51,7 +51,7 @@ interface ERC998ERC20TopDown {
 
     /// @notice Transfer ERC20 tokens to address
     /// @param _tokenId The token to transfer from
-    /// @param _value The address to send the ERC20 tokens to
+    /// @param _to The address to send the ERC20 tokens to
     /// @param _erc20Contract The ERC20 contract
     /// @param _value The number of ERC20 tokens to transfer
     function transferERC20(
@@ -63,7 +63,7 @@ interface ERC998ERC20TopDown {
 
     /// @notice Transfer ERC20 tokens to address or ERC20 top-down composable
     /// @param _tokenId The token to transfer from
-    /// @param _value The address to send the ERC20 tokens to
+    /// @param _to The address to send the ERC20 tokens to
     /// @param _erc223Contract The ERC223 token contract
     /// @param _value The number of ERC20 tokens to transfer
     /// @param _data Additional data with no specified format, can be used to specify tokenId to transfer to
@@ -72,7 +72,7 @@ interface ERC998ERC20TopDown {
         address _to,
         address _erc223Contract,
         uint256 _value,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Get ERC20 tokens from ERC20 contract.

--- a/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC20TopDown.sol
@@ -2,10 +2,12 @@
 
 pragma solidity ^0.7.5;
 
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
 /// @title ERC998ERC20 Top-Down Composable Non-Fungible Token
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
 ///  Note: the ERC-165 identifier for this interface is 0x7294ffed
-interface ERC998ERC20TopDown {
+interface IERC998ERC20TopDown is IERC721 {
     /// @dev This emits when a token receives ERC20 tokens.
     /// @param _from The prior owner of the token.
     /// @param _toTokenId The token that receives the ERC20 tokens.

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
@@ -2,10 +2,12 @@
 
 pragma solidity ^0.7.5;
 
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
 /// @title ERC998ERC721 Bottom-Up Composable Non-Fungible Token
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
 ///  Note: the ERC-165 identifier for this interface is 0xa1b23002
-interface ERC998ERC721BottomUp {
+interface IERC998ERC721BottomUp is IERC721 {
     /// @dev This emits when a token is transferred to an ERC721 token
     /// @param _toContract The contract the token is transferred to
     /// @param _toTokenId The token the token is transferred to

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721BottomUp.sol
@@ -53,14 +53,15 @@ interface IERC998ERC721BottomUp is IERC721 {
     /// @notice Transfer token from owner address to a token
     /// @param _from The owner address
     /// @param _toContract The ERC721 contract of the receiving token
-    /// @param _toToken The receiving token
+    /// @param _toTokenId The receiving token
+    /// @param _tokenId The token to transfer
     /// @param _data Additional data with no specified format
     function transferToParent(
         address _from,
         address _toContract,
         uint256 _toTokenId,
         uint256 _tokenId,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Transfer token from a token to an address
@@ -74,14 +75,14 @@ interface IERC998ERC721BottomUp is IERC721 {
         uint256 _fromTokenId,
         address _to,
         uint256 _tokenId,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Transfer a token from a token to another token
     /// @param _fromContract The address of the owning contract
     /// @param _fromTokenId The owning token
     /// @param _toContract The ERC721 contract of the receiving token
-    /// @param _toToken The receiving token
+    /// @param _toTokenId The receiving token
     /// @param _tokenId The token that is transferred
     /// @param _data Additional data with no specified format
     function transferAsChild(
@@ -90,7 +91,7 @@ interface IERC998ERC721BottomUp is IERC721 {
         address _toContract,
         uint256 _toTokenId,
         uint256 _tokenId,
-        bytes _data
+        bytes calldata _data
     ) external;
 }
 

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
@@ -30,7 +30,7 @@ interface ERC998ERC721TopDown {
     /// @param _tokenId The token to query for a root owner address
     /// @return rootOwner The root owner at the top of tree of tokens and ERC998 magic value.
     function rootOwnerOf(uint256 _tokenId)
-        public
+        external
         view
         returns (bytes32 rootOwner);
 
@@ -39,7 +39,7 @@ interface ERC998ERC721TopDown {
     /// @param _childTokenId The tokenId of the child.
     /// @return rootOwner The root owner at the top of tree of tokens and ERC998 magic value.
     function rootOwnerOfChild(address _childContract, uint256 _childTokenId)
-        public
+        external
         view
         returns (bytes32 rootOwner);
 
@@ -62,7 +62,7 @@ interface ERC998ERC721TopDown {
         address _operator,
         address _from,
         uint256 _childTokenId,
-        bytes _data
+        bytes calldata _data
     ) external returns (bytes4);
 
     /// @notice Transfer child token from top-down composable to address.
@@ -100,13 +100,13 @@ interface ERC998ERC721TopDown {
         address _to,
         address _childContract,
         uint256 _childTokenId,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Transfer bottom-up composable child token from top-down composable to other ERC721 token.
     /// @param _fromTokenId The owning token to transfer from.
     /// @param _toContract The ERC721 contract of the receiving token
-    /// @param _toToken The receiving token
+    /// @param _toTokenId The receiving token
     /// @param _childContract The bottom-up composable contract of the child token.
     /// @param _childTokenId The token that is being transferred.
     /// @param _data Additional data with no specified format
@@ -116,7 +116,7 @@ interface ERC998ERC721TopDown {
         uint256 _toTokenId,
         address _childContract,
         uint256 _childTokenId,
-        bytes _data
+        bytes calldata _data
     ) external;
 
     /// @notice Get a child token from an ERC721 contract.

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.7.5;
 
 /// @title ERC998ERC721 Top-Down Composable Non-Fungible Token
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md

--- a/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
+++ b/backend/contracts/interfaces/ERC998/IERC998ERC721TopDown.sol
@@ -2,10 +2,12 @@
 
 pragma solidity ^0.7.5;
 
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
 /// @title ERC998ERC721 Top-Down Composable Non-Fungible Token
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-998.md
 ///  Note: the ERC-165 identifier for this interface is 0x1efdf36a
-interface ERC998ERC721TopDown {
+interface IERC998ERC721TopDown is IERC721 {
     /// @dev This emits when a token receives a child token.
     /// @param _from The prior owner of the token.
     /// @param _toTokenId The token that receives the child token.


### PR DESCRIPTION
This is related to issues #30 and #31.

The following are the changes:

- Changed interface names to correctly denote they are interfaces
- Added correct inheritance in interfaces to clarify they are extensions to prior ERCs
- Fixed docstrings which previously threw errors when trying to compile
- Changed function visibility to external for interfaces
- Changed location of bytes paramters to calldata as recommendation by compiler